### PR TITLE
Remove trailing comma to support python 3.5

### DIFF
--- a/BAC0/core/devices/Device.py
+++ b/BAC0/core/devices/Device.py
@@ -137,7 +137,7 @@ class Device(SQLMixin):
         save_resampling="1s",
         clear_history_on_save=False,
         history_size=None,
-        reconnect_on_failure=True,
+        reconnect_on_failure=True
     ):
 
         self.properties = DeviceProperties()


### PR DESCRIPTION
Python 3.5 does not support trailing commas following a catch-all argument https://bugs.python.org/issue9232

addresses https://github.com/ChristianTremblay/BAC0/issues/256